### PR TITLE
fix bug as mentioned in #64

### DIFF
--- a/src/main/java/net/tylermurphy/hideAndSeek/game/PlayerLoader.java
+++ b/src/main/java/net/tylermurphy/hideAndSeek/game/PlayerLoader.java
@@ -70,7 +70,6 @@ public class PlayerLoader {
     }
 
     public static void resetPlayer(Player player, Board board){
-        if(board.isSeeker(player)) return;
         loadPlayer(player);
         if (board.isSeeker(player)) {
             if (pvpEnabled)


### PR DESCRIPTION
**Describe the change**
Reverting a change from commit "[1.5.0 Release Candidate 4](https://github.com/tylermurphy534/KenshinsHideAndSeek/commit/2169712940956f3cd9ada7e84608a4a3592b293a)"

**Expected behavior**
Actually resets seekers, too.

**Screenshots**
Not applicable.

**Additional context**
I don't know for what reason this was introduced in the first place, so if there is other reasoning for it being there, stuff should be split up more clearly in order to still reset seekers.
